### PR TITLE
Add VisionKit business card scanner

### DIFF
--- a/NetPriorityAI.xcodeproj/project.pbxproj
+++ b/NetPriorityAI.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+                                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -380,7 +380,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+                                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -400,9 +400,10 @@
 				DEVELOPMENT_TEAM = RFRYGULZBC;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to scan business cards.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -428,9 +429,10 @@
 				DEVELOPMENT_TEAM = RFRYGULZBC;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to scan business cards.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -454,7 +456,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RFRYGULZBC;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+                                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.lunghao.NetPriorityAITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -473,7 +475,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RFRYGULZBC;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+                                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.lunghao.NetPriorityAITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/NetPriorityAI/ContentView.swift
+++ b/NetPriorityAI/ContentView.swift
@@ -1,61 +1,74 @@
-//
-//  ContentView.swift
-//  NetPriorityAI
-//
-//  Created by Howard Private on 9/8/25.
-//
-
 import SwiftUI
-import SwiftData
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
+    @State private var showScanner = false
+    @State private var frontImage: UIImage?
+    @State private var backImage: UIImage?
+    @State private var alertMessage: String?
 
     var body: some View {
-        NavigationSplitView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
+        NavigationView {
+            VStack(spacing: 16) {
+                if let frontImage = frontImage, let backImage = backImage {
+                    VStack {
+                        Text("Front")
+                        Image(uiImage: frontImage)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxHeight: 150)
+                        Text("Back")
+                        Image(uiImage: backImage)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxHeight: 150)
                     }
+                } else {
+                    Text("No business card scanned yet")
+                        .foregroundStyle(.secondary)
                 }
-                .onDelete(perform: deleteItems)
+
+                Button("Scan Business Card") {
+                    showScanner = true
+                }
+                .padding()
             }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
+            .navigationTitle("Business Card Scanner")
+        }
+        .sheet(isPresented: $showScanner) {
+            ScannerView { result in
+                switch result {
+                case .success(let images):
+                    frontImage = images.front
+                    backImage = images.back
+                case .failure(let error):
+                    alertMessage = message(for: error)
                 }
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
-                }
+                showScanner = false
             }
-        } detail: {
-            Text("Select an item")
+        }
+        .alert(item: $alertMessage) { message in
+            Alert(title: Text("Scanner Error"), message: Text(message), dismissButton: .default(Text("OK")))
         }
     }
 
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
-            }
+    private func message(for error: ScannerCoordinator.ScannerError) -> String {
+        switch error {
+        case .unavailable:
+            return "VisionKit scanner is not available on this device."
+        case .cancelled:
+            return "Scanning was cancelled."
+        case .failed:
+            return "Failed to capture image."
+        case .underlying(let err):
+            return err.localizedDescription
         }
     }
 }
 
+extension String: Identifiable {
+    public var id: String { self }
+}
+
 #Preview {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
 }

--- a/NetPriorityAI/NetPriorityAIApp.swift
+++ b/NetPriorityAI/NetPriorityAIApp.swift
@@ -6,27 +6,12 @@
 //
 
 import SwiftUI
-import SwiftData
 
 @main
 struct NetPriorityAIApp: App {
-    var sharedModelContainer: ModelContainer = {
-        let schema = Schema([
-            Item.self,
-        ])
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-
-        do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
-        } catch {
-            fatalError("Could not create ModelContainer: \(error)")
-        }
-    }()
-
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
-        .modelContainer(sharedModelContainer)
     }
 }

--- a/NetPriorityAI/ScannerCoordinator.swift
+++ b/NetPriorityAI/ScannerCoordinator.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import VisionKit
+
+final class ScannerCoordinator: NSObject, VNDocumentCameraViewControllerDelegate {
+    enum Phase { case front, back }
+    enum ScannerError: Error {
+        case unavailable
+        case cancelled
+        case failed
+        case underlying(Error)
+    }
+
+    private var phase: Phase = .front
+    private var frontImage: UIImage?
+    private let completion: (Result<(front: UIImage, back: UIImage), ScannerError>) -> Void
+
+    init(completion: @escaping (Result<(front: UIImage, back: UIImage), ScannerError>) -> Void) {
+        self.completion = completion
+    }
+
+    func start(on presenter: UIViewController) {
+        guard VNDocumentCameraViewController.isSupported else {
+            completion(.failure(.unavailable))
+            return
+        }
+        presentScanner(on: presenter)
+    }
+
+    private func presentScanner(on presenter: UIViewController) {
+        let scanner = VNDocumentCameraViewController()
+        scanner.delegate = self
+        presenter.present(scanner, animated: true)
+    }
+
+    func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
+        guard scan.pageCount > 0 else {
+            controller.dismiss(animated: true) { [weak self] in
+                self?.completion(.failure(.failed))
+            }
+            return
+        }
+        let image = scan.imageOfPage(at: 0)
+        switch phase {
+        case .front:
+            frontImage = image
+            phase = .back
+            controller.dismiss(animated: true) { [weak self] in
+                guard let self = self, let presenter = controller.presentingViewController else { return }
+                let alert = UIAlertController(title: "Scan Back", message: "Flip the business card and scan the back side.", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "Continue", style: .default) { _ in
+                    self.presentScanner(on: presenter)
+                })
+                presenter.present(alert, animated: true)
+            }
+        case .back:
+            controller.dismiss(animated: true) { [weak self] in
+                guard let self = self, let front = self.frontImage else {
+                    self?.completion(.failure(.failed))
+                    return
+                }
+                self.completion(.success((front: front, back: image)))
+            }
+        }
+    }
+
+    func documentCameraViewControllerDidCancel(_ controller: VNDocumentCameraViewController) {
+        controller.dismiss(animated: true) { [weak self] in
+            self?.completion(.failure(.cancelled))
+        }
+    }
+
+    func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFailWithError error: Error) {
+        controller.dismiss(animated: true) { [weak self] in
+            self?.completion(.failure(.underlying(error)))
+        }
+    }
+}

--- a/NetPriorityAI/ScannerView.swift
+++ b/NetPriorityAI/ScannerView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import VisionKit
+
+struct ScannerView: UIViewControllerRepresentable {
+    typealias Completion = (Result<(front: UIImage, back: UIImage), ScannerCoordinator.ScannerError>) -> Void
+
+    let completion: Completion
+
+    func makeCoordinator() -> ScannerCoordinator {
+        ScannerCoordinator(completion: completion)
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        let controller = UIViewController()
+        controller.view.backgroundColor = .clear
+        DispatchQueue.main.async {
+            context.coordinator.start(on: controller)
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}


### PR DESCRIPTION
## Summary
- add SwiftUI wrapper and coordinator for VisionKit document scanner
- present sequential front/back capture with guidance and error handling
- integrate scanner demo view and camera privacy description

## Testing
- ⚠️ `xcodebuild -list` *(command not found)*
- ⚠️ `swift test` *(no Package.swift found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8edad1cc832687c998f707f9235a