### PR TITLE
feat: add fullscreen event creation sheet

### DIFF
--- a/NetPriorityAI/Models/Event.swift
+++ b/NetPriorityAI/Models/Event.swift
@@ -1,0 +1,31 @@
+//
+//  Event.swift
+//  NetPriorityAI
+//
+//  Created by Lung Hao Tung on 9/14/25.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class Event {
+    var eventName: String
+    var eventLocation: String?
+    var goal: String?
+    var eventDescription: String?
+    // TODO: Image function for later
+    // var image: Data?
+
+    init(
+        eventName: String,
+        eventLocation: String?,
+        goal: String?,
+        eventDescription: String?
+    ) {
+        self.eventName = eventName
+        self.eventLocation = eventLocation
+        self.goal = goal
+        self.eventDescription = eventDescription
+    }
+}

--- a/NetPriorityAI/NetPriorityAIApp.swift
+++ b/NetPriorityAI/NetPriorityAIApp.swift
@@ -5,19 +5,26 @@
 //  Created by Lung Hao Tung on 9/8/25.
 //
 
-import SwiftUI
 import SwiftData
+import SwiftUI
+import TipKit
 
 @main
 struct NetPriorityAIApp: App {
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
-            Item.self,
+            Item.self
         ])
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+        let modelConfiguration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: false
+        )
 
         do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+            return try ModelContainer(
+                for: schema,
+                configurations: [modelConfiguration]
+            )
         } catch {
             fatalError("Could not create ModelContainer: \(error)")
         }
@@ -26,7 +33,24 @@ struct NetPriorityAIApp: App {
     var body: some Scene {
         WindowGroup {
             MainView()
+                .task {
+                    do {
+                        // Configure and load your tips at app launch.
+                        #if DEBUG
+                            try Tips.resetDatastore()
+                        #endif
+
+                        try Tips.configure()
+
+                    } catch {
+                        // Handle TipKit errors
+                        print(
+                            "Error initializing TipKit \(error.localizedDescription)"
+                        )
+                    }
+                }
         }
         .modelContainer(sharedModelContainer)
     }
+
 }

--- a/NetPriorityAI/ViewModels/AddEventViewModel.swift
+++ b/NetPriorityAI/ViewModels/AddEventViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  AddEventViewModel.swift
+//  NetPriorityAI
+//
+//  Created by Lung Hao Tung on 9/14/25.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+class AddEventViewModel: ObservableObject {
+    var modelContext: ModelContext?
+    
+    func AddEvent(event: Event) {
+        guard let modelContext = modelContext else {return}
+        //TODO: Insert event into database
+    }
+}

--- a/NetPriorityAI/ViewModels/AddEventViewModel.swift
+++ b/NetPriorityAI/ViewModels/AddEventViewModel.swift
@@ -14,6 +14,7 @@ class AddEventViewModel: ObservableObject {
     
     func AddEvent(event: Event) {
         guard let modelContext = modelContext else {return}
-        //TODO: Insert event into database
+        
+            //TODO: Insert event into database
     }
 }

--- a/NetPriorityAI/Views/AddEventView.swift
+++ b/NetPriorityAI/Views/AddEventView.swift
@@ -1,22 +1,39 @@
-import SwiftUI
+import MapKit
 import PhotosUI
+import SwiftUI
+import TipKit
 
 struct AddEventView: View {
     @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel = AddEventViewModel()
     @State private var eventName = ""
     @State private var eventLocation = ""
     @State private var eventGoal = ""
     @State private var eventDescription = ""
-
     @State private var selectedPhoto: PhotosPickerItem? = nil
     @State private var selectedImageData: Data? = nil
 
+    //TODO: Map feature
+    //    private let myHome = CLLocationCoordinate2D(
+    //        latitude: 40.7493963,
+    //        longitude: -111.899047
+    //    )
+
     var body: some View {
-        NavigationView {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+        let goalTip = GeneralPopOverTip(
+            title: Text("Purpose"),
+            message: Text(
+                "Giving goal for this event helps AI better analyze result."
+            ),
+        )
+
+        NavigationStack {
+            Form {
+                Section {
                     PhotosPicker(selection: $selectedPhoto, matching: .images) {
-                        if let data = selectedImageData, let uiImage = UIImage(data: data) {
+                        if let data = selectedImageData,
+                            let uiImage = UIImage(data: data)
+                        {
                             Image(uiImage: uiImage)
                                 .resizable()
                                 .scaledToFill()
@@ -34,43 +51,101 @@ struct AddEventView: View {
                             }
                         }
                     }
-                    .onChange(of: selectedPhoto) { newValue in
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .listRowBackground(Color.clear)
+                    .listRowInsets(EdgeInsets())
+                    .onChange(of: selectedPhoto, initial: false) {
+                        oldValue,
+                        newValue in
                         if let newValue {
                             Task {
-                                if let data = try? await newValue.loadTransferable(type: Data.self) {
+                                if let data =
+                                    try? await newValue.loadTransferable(
+                                        type: Data.self
+                                    )
+                                {
                                     selectedImageData = data
                                 }
                             }
                         }
                     }
-
-                    Group {
-                        TextField("Event Name", text: $eventName)
-                            .textFieldStyle(.roundedBorder)
-                        TextField("Event Location", text: $eventLocation)
-                            .textFieldStyle(.roundedBorder)
-                        TextField("Event Goal", text: $eventGoal)
-                            .textFieldStyle(.roundedBorder)
-                        TextField("Description", text: $eventDescription)
-                            .textFieldStyle(.roundedBorder)
-                    }
-                    .padding(.horizontal)
                 }
+
+                Section {
+                    TextField("Event Name", text: $eventName)
+                    TextField("Location", text: $eventLocation)
+                    TextField(
+                        "What's ur goal for this event?",
+                        text: $eventGoal
+                    )
+                    .padding(.trailing, 28)
+                    .overlay(alignment: .trailing) {
+                        Button(
+                            action: {
+                                GeneralPopOverTip.buttonPressed = true
+                            }) {
+                                Image(systemName: "lightbulb")
+                                    .imageScale(.medium)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .popoverTip(goalTip, arrowEdge: .top)
+
+                    }
+                    TextField(
+                        "Description",
+                        text: $eventDescription,
+                        axis: .vertical
+                    )
+                    .lineLimit(5...8)
+                }
+
+                //                Section {
+                //                    Map {
+                //                        Annotation(
+                //                            "San Francisco City Hall",
+                //                            coordinate: myHome
+                //                        ) {
+                //                            ZStack {
+                //                                RoundedRectangle(cornerRadius: 5)
+                //                                    .fill(Color.yellow)
+                //                                Text("🛝")
+                //                                    .padding(5)
+                //                            }
+                //                        }
+                //
+                //                    }
+                //
+                //                    .frame(height: 200)
+                //                    .frame(maxWidth: .infinity)
+                //                    .listRowBackground(Color.clear)
+                //                    .listRowInsets(EdgeInsets())
+                //                }
             }
             .navigationTitle("New Event")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Add") { dismiss() }
+                    Button("Add") {
+                        // Navigate to next screen
+                        dismiss()
+                    }
                 }
             }
         }
+
         .ignoresSafeArea()
+        .onDisappear {
+            GeneralPopOverTip.buttonPressed = false
+        }
+
     }
+
 }
 
-#Preview {
-    AddEventView()
-}
+//#Preview {
+//    AddEventView()
+//}

--- a/NetPriorityAI/Views/AddEventView.swift
+++ b/NetPriorityAI/Views/AddEventView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import PhotosUI
+
+struct AddEventView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var eventName = ""
+    @State private var eventLocation = ""
+    @State private var eventGoal = ""
+    @State private var eventDescription = ""
+
+    @State private var selectedPhoto: PhotosPickerItem? = nil
+    @State private var selectedImageData: Data? = nil
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    PhotosPicker(selection: $selectedPhoto, matching: .images) {
+                        if let data = selectedImageData, let uiImage = UIImage(data: data) {
+                            Image(uiImage: uiImage)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(height: 200)
+                                .frame(maxWidth: .infinity)
+                                .clipped()
+                        } else {
+                            ZStack {
+                                Rectangle()
+                                    .fill(Color.gray.opacity(0.3))
+                                    .frame(height: 200)
+                                Image(systemName: "photo")
+                                    .font(.largeTitle)
+                                    .foregroundColor(.gray)
+                            }
+                        }
+                    }
+                    .onChange(of: selectedPhoto) { newValue in
+                        if let newValue {
+                            Task {
+                                if let data = try? await newValue.loadTransferable(type: Data.self) {
+                                    selectedImageData = data
+                                }
+                            }
+                        }
+                    }
+
+                    Group {
+                        TextField("Event Name", text: $eventName)
+                            .textFieldStyle(.roundedBorder)
+                        TextField("Event Location", text: $eventLocation)
+                            .textFieldStyle(.roundedBorder)
+                        TextField("Event Goal", text: $eventGoal)
+                            .textFieldStyle(.roundedBorder)
+                        TextField("Description", text: $eventDescription)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                    .padding(.horizontal)
+                }
+            }
+            .navigationTitle("New Event")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") { dismiss() }
+                }
+            }
+        }
+        .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    AddEventView()
+}

--- a/NetPriorityAI/Views/AddEventView.swift
+++ b/NetPriorityAI/Views/AddEventView.swift
@@ -130,13 +130,19 @@ struct AddEventView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add") {
-                        // Navigate to next screen
+                        let event: Event = Event(
+                            eventName: eventName,
+                            eventLocation: eventLocation,
+                            goal: eventGoal,
+                            eventDescription: eventDescription
+                        )
+                        viewModel.AddEvent(event: event)
                         dismiss()
-                    }
+                    }.disabled(eventName.isEmpty)
                 }
+
             }
         }
-
         .ignoresSafeArea()
         .onDisappear {
             GeneralPopOverTip.buttonPressed = false
@@ -146,6 +152,6 @@ struct AddEventView: View {
 
 }
 
-//#Preview {
-//    AddEventView()
-//}
+#Preview {
+    AddEventView()
+}

--- a/NetPriorityAI/Views/EventView.swift
+++ b/NetPriorityAI/Views/EventView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct EventView: View {
+    @Environment(\.dismiss) private var dismiss
+    let event: Event
+    
+    var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    Text(eventDisplayText)
+                        .font(.body)
+                        .padding()
+                }
+            }
+            .navigationTitle("Event Details")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Close") {
+                        dismiss()
+                    }
+                }
+            }
+        
+    }
+    
+    private var eventDisplayText: String {
+        var text = ""
+        
+        text += "Event Name: \(event.eventName)\n\n"
+        
+        if let location = event.eventLocation, !location.isEmpty {
+            text += "Location: \(location)\n\n"
+        }
+        
+        if let goal = event.goal, !goal.isEmpty {
+            text += "Goal: \(goal)\n\n"
+        }
+        
+        if let description = event.eventDescription, !description.isEmpty {
+            text += "Description: \(description)\n\n"
+        }
+        
+        return text
+    }
+}
+
+#Preview {
+    let sampleEvent = Event(
+        eventName: "Sample Event",
+        eventLocation: "Sample Location",
+        goal: "Sample Goal",
+        eventDescription: "This is a sample event description for preview purposes."
+    )
+    return EventView(event: sampleEvent)
+}

--- a/NetPriorityAI/Views/HomeView.swift
+++ b/NetPriorityAI/Views/HomeView.swift
@@ -28,6 +28,7 @@ struct HomeView: View {
                     viewModel.deleteItems(items: items, offsets: offsets)
                 }
             }
+            
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     EditButton()
@@ -38,16 +39,24 @@ struct HomeView: View {
                     } label: {
                         Label("Add Item", systemImage: "plus")
                     }
+                    .sheet(isPresented: $showingAddEvent) {
+                        AddEventView()
+                    }
                 }
             }
+            .navigationTitle("Events")
             .onAppear {
                 viewModel.modelContext = modelContext
             }
         } detail: {
             Text("Select an item")
         }
-        .fullScreenCover(isPresented: $showingAddEvent) {
-            AddEventView()
-        }
+
+        
     }
+}
+
+
+#Preview {
+    HomeView()
 }

--- a/NetPriorityAI/Views/HomeView.swift
+++ b/NetPriorityAI/Views/HomeView.swift
@@ -12,6 +12,7 @@ struct HomeView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var items: [Item]
     @StateObject private var viewModel = HomeViewModel()
+    @State private var showingAddEvent = false
 
     var body: some View {
         NavigationSplitView {
@@ -32,7 +33,9 @@ struct HomeView: View {
                     EditButton()
                 }
                 ToolbarItem {
-                    Button(action: viewModel.addItem) {
+                    Button {
+                        showingAddEvent = true
+                    } label: {
                         Label("Add Item", systemImage: "plus")
                     }
                 }
@@ -42,6 +45,9 @@ struct HomeView: View {
             }
         } detail: {
             Text("Select an item")
+        }
+        .fullScreenCover(isPresented: $showingAddEvent) {
+            AddEventView()
         }
     }
 }

--- a/NetPriorityAI/Views/TipsView.swift
+++ b/NetPriorityAI/Views/TipsView.swift
@@ -18,9 +18,9 @@ extension GeneralPopOverTip {
     
     var rules: [Rule] {
         [
-            #Rule(Self.$buttonPressed) {
-                $0 == true
-            }
+//            #Rule(Self.$buttonPressed) {
+//                $0 == true
+//            }
         ]
     }
 }

--- a/NetPriorityAI/Views/TipsView.swift
+++ b/NetPriorityAI/Views/TipsView.swift
@@ -1,0 +1,28 @@
+//
+//  TipView.swift
+//  NetPriorityAI
+//
+//  Created by Lung Hao Tung on 9/13/25.
+//
+import SwiftUI
+import TipKit
+
+struct GeneralPopOverTip: Tip {
+    let title: Text
+    let message: Text?
+}
+
+extension GeneralPopOverTip {
+    @Parameter
+    static var buttonPressed: Bool = false
+    
+    var rules: [Rule] {
+        [
+            #Rule(Self.$buttonPressed) {
+                $0 == true
+            }
+        ]
+    }
+}
+
+


### PR DESCRIPTION
## Summary
- show AddEventView as a full-screen sheet from HomeView's Add Item button
- let users enter event details including name, image, location, goal, and description
- display a gray placeholder when no image is selected

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c607c70efc8326bf9f7e65cb749660